### PR TITLE
Make the grammar PCRE compatible

### DIFF
--- a/Syntaxes/OpenSCAD.tmLanguage
+++ b/Syntaxes/OpenSCAD.tmLanguage
@@ -126,7 +126,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\\(x\h{2}|[0-2][0-7]{,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)</string>
+					<string>\\(x\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)</string>
 					<key>name</key>
 					<string>constant.character.escape.scad</string>
 				</dict>
@@ -159,7 +159,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\\(x\h{2}|[0-2][0-7]{,2}|3[0-6][0-7]|37[0-7]?|[4-7][0-7]?|.)</string>
+					<string>\\(x\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]|37[0-7]?|[4-7][0-7]?|.)</string>
 					<key>name</key>
 					<string>constant.character.escape.scad</string>
 				</dict>

--- a/Syntaxes/OpenSCAD.tmLanguage
+++ b/Syntaxes/OpenSCAD.tmLanguage
@@ -126,7 +126,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\\(x\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)</string>
+					<string>\\(x[0-9A-Fa-f]{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)</string>
 					<key>name</key>
 					<string>constant.character.escape.scad</string>
 				</dict>
@@ -159,7 +159,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\\(x\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]|37[0-7]?|[4-7][0-7]?|.)</string>
+					<string>\\(x[0-9A-Fa-f]{2}|[0-2][0-7]{0,2}|3[0-6][0-7]|37[0-7]?|[4-7][0-7]?|.)</string>
 					<key>name</key>
 					<string>constant.character.escape.scad</string>
 				</dict>


### PR DESCRIPTION
This pull request changes 1 regular expressions in an attempt to make the grammar PCRE-compatible. While TextMate uses an Oniguruma engine, github.com (which rely on this grammar for YAML highlighting) uses a PCRE-based engine. The two engines interpret `\h` differently, and only Oniguruma engines support implicit count modifiers (`{,n}`).